### PR TITLE
fix: radiology assigned table with hadm_ids

### DIFF
--- a/database/sql/note/assign_events.sql
+++ b/database/sql/note/assign_events.sql
@@ -17,7 +17,14 @@ SET CLIENT_ENCODING TO 'utf8';
 DROP TABLE IF EXISTS mimiciv_note.radiology_assigned;
 CREATE TABLE mimiciv_note.radiology_assigned AS
 SELECT
-    r.*
+    r.note_id,
+    r.subject_id,
+    subquery.hadm_id,
+    r.note_type,
+    r.note_seq,
+    r.charttime,
+    r.storetime,
+    r.text
 FROM mimiciv_note.radiology r
 INNER JOIN (
     SELECT


### PR DESCRIPTION
Fixes the creation of the radiology table with the missing hadm_id #76
Still needs to be rerun for the fix to persist in the table