### PR TITLE
Replace Devstral2 with MistralSmall3.2 configuration

### DIFF
--- a/configs/vllm_config/mistralSmall3.2_24B.yaml
+++ b/configs/vllm_config/mistralSmall3.2_24B.yaml
@@ -1,4 +1,4 @@
-model: "mistralai/Devstral-Small-2-24B-Instruct-2512" 
+model: "mistralai/Mistral-Small-3.2-24B-Instruct-2506" 
 download_dir: /srv/llm-weights
 served-model-name: "default"
 host: "localhost"


### PR DESCRIPTION
In my Last PR i mistakenly took the LLM that was fine-tuned for coding, this PR replaces it with normal Mistral 3.2 Small version